### PR TITLE
fix: update schedule interval for PX4 log download DAG and increase l…

### DIFF
--- a/orchestration/dags/download_px4_logs.py
+++ b/orchestration/dags/download_px4_logs.py
@@ -12,7 +12,7 @@ with DAG(
     dag_id='download_px4_logs_pipeline',
     default_args=default_args,
     description='Runs PX4 log download after setting environment',
-    schedule_interval=None,
+    schedule_interval='*/30 * * * *',  # Every 30 minutes
     start_date=days_ago(1),
     catchup=False,
     tags=['px4', 'emr', 'logs']

--- a/orchestration/emr_jobs/download_px4_logs/main.py
+++ b/orchestration/emr_jobs/download_px4_logs/main.py
@@ -35,7 +35,7 @@ session = dbclient.get_session()
 repo = LogDlRepository(session)
 
 # Fetch logs to process
-records = repo.get_new_log_entries(limit=5)  # Increase this as needed
+records = repo.get_new_log_entries(limit=50)  # Increase this as needed
 job_id = JOB_ID
 log_ts_utc = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
 


### PR DESCRIPTION
This pull request includes updates to the PX4 log download pipeline to improve its scheduling and processing efficiency. The most important changes include modifying the schedule interval for the DAG and increasing the batch size for log processing.

**Pipeline scheduling updates:**

* [`orchestration/dags/download_px4_logs.py`](diffhunk://#diff-7471ffab9939e68b9baa9e8199836eb5b3cf4d16fd4cf1199d5aaa5aba0d7fb8L15-R15): Changed the `schedule_interval` for the DAG from `None` to `'*/30 * * * *'`, ensuring the pipeline runs every 30 minutes.

**Log processing efficiency:**

* [`orchestration/emr_jobs/download_px4_logs/main.py`](diffhunk://#diff-1f41fcc5238680a3d112f5c3b38cb7704677039e02a4e2f5f16ed9f52ad6fe75L38-R38): Increased the `limit` parameter in the `get_new_log_entries` method from 5 to 50, allowing the pipeline to process larger batches of logs in each run.…og entry limit